### PR TITLE
Change release of master builds from 1 to 100

### DIFF
--- a/build-schema.md
+++ b/build-schema.md
@@ -6,7 +6,7 @@ like that (NVR without %{dist}):
 
 - for builds made from the master branch:
 ```
-<name>-<version>-1.<timestamp>.<short-hash>.<branch>
+<name>-<version>-100.<timestamp>.<short-hash>.<branch>
 ```
 - for builds made from pull-request:
 ```


### PR DESCRIPTION
It's a retrospective update, we are already using that schema in our CD.